### PR TITLE
Merge default options with provided options and provide defaults for pug

### DIFF
--- a/src/transformers/pug.js
+++ b/src/transformers/pug.js
@@ -1,6 +1,11 @@
 const pug = require('pug')
 
-module.exports = function({ content, filename, options }) {
-  const code = pug.render(content, options)
+module.exports = function({ content, filename, options = {} }) {
+  let opts = Object.assign({
+    doctype: 'html',
+    filename,
+  }, options);
+
+  const code = pug.render(content, opts)
   return { code }
 }

--- a/src/transformers/scss.js
+++ b/src/transformers/scss.js
@@ -5,17 +5,19 @@ const { getIncludePaths } = require('../utils.js')
 module.exports = function({
   content,
   filename,
-  options = {
-    includePaths: getIncludePaths(filename),
-  },
+  options = {},
 }) {
+  let opts = Object.assign({
+    includePaths: getIncludePaths(filename),
+  }, options);
+
   return new Promise((resolve, reject) => {
     sass.render(
       {
         data: content,
         sourceMap: true,
         outFile: filename + '.css',
-        ...options,
+        ...opts,
       },
       (err, result) => {
         if (err) return reject(err)

--- a/src/transformers/stylus.js
+++ b/src/transformers/stylus.js
@@ -5,15 +5,17 @@ const { getIncludePaths } = require('../utils.js')
 module.exports = function({
   content,
   filename,
-  options = {
-    paths: getIncludePaths(filename),
-  },
+  options = {},
 }) {
+  let opts = Object.assign({
+    includePaths: getIncludePaths(filename),
+  }, options);
+
   return new Promise((resolve, reject) => {
     const style = stylus(content, {
       filename,
       sourcemap: true,
-      ...options,
+      ...opts,
     })
 
     style.render((err, css) => {


### PR DESCRIPTION
Thank you for your efforts with svelte-preprocess. I'm exploring svelte right now and prefer sass and pug. Your repo saved me the time and effort of writing my own hooks to preprocess. 👍 

Having include paths for sass and stylus is good, but unfortunately I was finding the default code paths passed in an empty options object (in [utils.js/runTransformer()](https://github.com/kaisermann/svelte-preprocess/blob/975b08f60ce0ef5d3c9a0ff3caa49949e967b274/src/utils.js#L97)). So, the include paths aren't added by default. This PR merges in the default options with `Object.assign()`. (We could reuse the `options` variable. I opted for a new `opts` variable for clarity but can change it.)

This PR also plumbs through sensible defaults for pug - the filename (fixes imports) and html as the default doctype (fixes boolean attributes).

Thanks again!