### PR TITLE
Allow short aliases to refer to application/* as well as text/* for json types

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ const options = {
      * <... src="file.cst"> or
      * <... lang="cst"> or
      * <... type="text/customLanguage">
+     * <... type="application/customLanguage">
      * will be treated as the language 'customLanguage'
     */
     ['cst', 'customLanguage']

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ exports.getLanguage = (attributes, defaultLang) => {
     lang = lang ? lang[1] : defaultLang
   } else {
     lang = attributes.type
-      ? attributes.type.replace('text/', '')
+      ? attributes.type.replace(/^(text|application)\/(.*)$/, '$2')
       : attributes.lang || defaultLang
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -258,6 +258,22 @@ describe('style - postcss', () => {
   })
 })
 
+describe('detect - mimetype', () => {
+  const MIMETYPES = [
+    { type: 'application/ld+json', parser: 'ld+json' },
+    { type: 'text/some-other', parser: 'some-other' },
+    { lang: 'stylus', parser: 'stylus' }
+  ]
+   MIMETYPES.forEach(({ type, lang, parser }) => {
+    it(`should detect ${type || lang} as ${parser}`, async () => {
+      expect(getLanguage({ type, lang }, 'javascript')).toEqual({
+        lang: parser,
+        alias: parser,
+      })
+    })
+  })
+})
+
 describe('externally hosted files', () => {
   const EXTERNALJS = [
     'https://www.example.com/some/externally/delivered/content.js',
@@ -338,7 +354,7 @@ describe('options', () => {
           return { code: content, map: '' }
         },
       },
-      aliases: [['application/ld+json', 'structuredData']],
+      aliases: [['ld+json', 'structuredData']],
     })
     const preprocessed = await preprocess(input, opts)
     expect(preprocessed).toContain(`{"json":true}`)


### PR DESCRIPTION
This is the rest of my fix - a few extra tests, but also removes the need for lang to always start with `text/`. Often json types use `application/`