### PR TITLE
allow ignoring of certain tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ const options = {
     */
     ['cst', 'customLanguage']
   ],
+  preserve: [
+    /**
+     * Using the same matching algorithm as above, don't parse,
+     * modify, or remove from the markup, tags which match the 
+     * language / types listed below.
+     * **/
+    'ld+json'
+  ]
 }
 
 svelte.preprocess(input, preprocess(options)).then(...)

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,12 @@ const {
 
 const TEMPLATE_PATTERN = getTagPattern('template')
 
-module.exports = ({ onBefore, transformers = {}, aliases } = {}) => {
+module.exports = ({
+  onBefore,
+  transformers = {},
+  aliases,
+  preserve = []
+} = {}) => {
   const optionsCache = {}
 
   if (aliases && aliases.length) {
@@ -49,6 +54,10 @@ module.exports = ({ onBefore, transformers = {}, aliases } = {}) => {
     filename,
   }) => {
     const { lang, alias } = getLanguage(attributes, targetLanguage)
+
+    if (preserve.indexOf(lang) > -1) {
+      return
+    }
 
     if (attributes.src) {
       if (attributes.src.match(/^(https?)?:?\/\/.*$/)) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -344,6 +344,20 @@ describe('options', () => {
     expect(preprocessed).toContain(`{"json":true}`)
   })
 
+  it('should support custom language transformers', async () => {
+    const input = `<div></div><script type="application/ld+json">{"json":true}</script>`
+    const opts = getPreprocess({
+      preserve: [ 'ld+json' ],
+      transformers: {
+        structuredData({ content }) {
+          return { code: content, map: '' }
+        },
+      }
+    })
+    const preprocessed = await preprocess(input, opts)
+    expect(preprocessed).toContain(`<script type="application/ld+json">{"json":true}</script>`)
+  })
+
   it('should allow to pass specific options to alias', async () => {
     const input = `
       <div></div>


### PR DESCRIPTION
Note, don't merge this until the other PR https://github.com/kaisermann/svelte-preprocess/pull/13 is merged - as it depends on the shorthand `application/json` -> `json` syntax used throughout the plugin, which the other pull provides!

This plugin allows certain tags to be totally excluded, such as the google markup which needs to stay intact and unbundled.