### PR TITLE
Add v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The preprocessor module installation is up to the developer.
 
 ## Usage
 
-### Basic
+### Auto Preprocessing
+
+#### Basic
 
 ```js
 const svelte = require('svelte')
@@ -26,7 +28,7 @@ const preprocess = require('svelte-preprocess')
 svelte.preprocess(input, preprocess({ /* options */ })).then(...)
 ```
 
-### Advanced
+#### Advanced
 
 ```js
 const svelte = require('svelte')
@@ -90,7 +92,7 @@ const options = {
   preserve: [
     /**
      * Using the same matching algorithm as above, don't parse,
-     * modify, or remove from the markup, tags which match the 
+     * modify, or remove from the markup, tags which match the
      * language / types listed below.
      * **/
     'ld+json'
@@ -99,6 +101,33 @@ const options = {
 
 svelte.preprocess(input, preprocess(options)).then(...)
 ```
+
+### Standalone processors
+
+Instead of a single processor, [Svelte v3 has added support for multiple processors](https://v3.svelte.technology/docs#svelte-preprocess). In case you want to manually configure your preprocessing step, `svelte-preprocess` exports these named processors: `pug`, `coffeescript` or `coffee`, `less`, `scss` or `sass`, `stylus`, `postcss`.
+
+```js
+svelte.preprocess(input, [
+  pug(),
+  coffee(),
+  scss(),
+]).then(...)
+```
+
+Every processor accepts an option object which is passed to its respective underlying tool.
+
+```js
+svelte.preprocess(input, [
+  scss(),
+  postcss({
+    plugins: [
+      require('autoprefixer')({ browsers: 'last 2 versions' })
+    ]
+  }),
+])
+```
+
+***Note:** there's no built-in support for \<template\> tag or external files when using standalone processors.*
 
 ### With `svelte-loader`
 
@@ -125,7 +154,9 @@ svelte.preprocess(input, preprocess(options)).then(...)
 
 ## Features
 
-### Template (a la Vue) tag support
+### Template tag support
+
+*Note: only for auto preprocessing*
 
 ```html
 <template>
@@ -139,6 +170,8 @@ svelte.preprocess(input, preprocess(options)).then(...)
 
 ## External files support
 
+*Note: only for auto preprocessing*
+
 ```html
 <template src="template.html"></template>
 <script src="./script.js"></script>
@@ -147,10 +180,9 @@ svelte.preprocess(input, preprocess(options)).then(...)
 
 ## Preprocessors support
 
-Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Coffeescript`, `Pug`.
+Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Coffeescript`, `Pug` and `PostCSS`.
 
 ```html
-
 <template lang="pug">
   div Hey
 </template>
@@ -183,6 +215,6 @@ Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Co
   $color = red
 
   div
-    color: $color
+    color: $color;
 </style>
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4723,7 +4723,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -5594,7 +5594,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -6738,9 +6738,9 @@
       }
     },
     "svelte": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-      "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg==",
+      "version": "3.0.0-beta.23",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.0.0-beta.23.tgz",
+      "integrity": "sha512-jn9AI6idldjcIOuFZkA/HvULv97jjrtS1FVh7bjnFx7i7IuDpMFRbn+WYmnPoW+JXvLMFnNa+BbraDfjrMARSg==",
       "dev": true
     },
     "symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "prettier": "^1.16.4",
     "pug": "^2.0.3",
     "stylus": "^0.54.5",
-    "svelte": "^2.16.1"
+    "svelte": "^3.0.0-beta.16"
   },
   "peerDependencies": {
-    "svelte": "^1.44.0 || ^2.0.0"
+    "svelte": "^1.44.0 || ^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "postcss-load-config": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "license": "MIT",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/autoProcess.js
+++ b/src/autoProcess.js
@@ -1,0 +1,159 @@
+const stripIndent = require('strip-indent')
+const {
+  addLanguageAlias,
+  getLanguage,
+  runTransformer,
+  isFn,
+  getSrcContent,
+  resolveSrc,
+  throwUnsupportedError,
+} = require('./utils.js')
+
+const ALIAS_OPTION_OVERRIDES = {
+  sass: {
+    indentedSyntax: true,
+  },
+}
+
+const TEMPLATE_PATTERN = new RegExp(
+  `<template([\\s\\S]*?)>([\\s\\S]*?)<\\/template>`,
+)
+
+module.exports = ({
+  onBefore,
+  transformers = {},
+  aliases,
+  preserve = [],
+} = {}) => {
+  const optionsCache = {}
+
+  const getTransformerOptions = (lang, alias) => {
+    if (isFn(transformers[alias])) return transformers[alias]
+    if (isFn(transformers[lang])) return transformers[lang]
+
+    if (typeof optionsCache[alias] === 'undefined') {
+      let opts = transformers[lang] || {}
+
+      if (lang !== alias) {
+        opts = {
+          ...opts,
+          ...(ALIAS_OPTION_OVERRIDES[alias] || {}),
+          ...(transformers[alias] || {}),
+        }
+      }
+
+      optionsCache[alias] = opts
+    }
+
+    return optionsCache[alias]
+  }
+
+  const getTransformerTo = targetLanguage => async ({
+    content = '',
+    attributes,
+    filename,
+  }) => {
+    const { lang, alias } = getLanguage(attributes, targetLanguage)
+    const dependencies = []
+
+    if (preserve.includes(lang) || preserve.includes(alias)) {
+      return
+    }
+
+    if (attributes.src) {
+      /** Ignore remote files */
+      if (attributes.src.match(/^(https?)?:?\/\/.*$/)) {
+        return
+      }
+      const file = resolveSrc(filename, attributes.src)
+      content = await getSrcContent(file)
+      dependencies.push(file)
+    }
+
+    if (lang === targetLanguage) {
+      return { code: content, dependencies }
+    }
+
+    if (transformers[lang] === false || transformers[alias] === false) {
+      throwUnsupportedError(alias, filename)
+    }
+
+    const transformedContent = await runTransformer(
+      lang,
+      getTransformerOptions(lang, alias),
+      {
+        content: stripIndent(content),
+        filename,
+      },
+    )
+
+    return {
+      ...transformedContent,
+      dependencies,
+    }
+  }
+
+  if (aliases && aliases.length) {
+    addLanguageAlias(aliases)
+  }
+
+  const scriptTransformer = getTransformerTo('javascript')
+  const cssTransformer = getTransformerTo('css')
+  const markupTransformer = getTransformerTo('html')
+
+  return {
+    async markup({ content, filename }) {
+      if (isFn(onBefore)) {
+        content = await onBefore({ content, filename })
+      }
+
+      const templateMatch = content.match(TEMPLATE_PATTERN)
+
+      /** If no <template> was found, just return the original markup */
+      if (!templateMatch) {
+        return { code: content }
+      }
+
+      const [fullMatch, attributesStr, templateCode] = templateMatch
+
+      /** Transform an attribute string into a key-value object */
+      const attributes = attributesStr
+        .split(/\s+/)
+        .filter(Boolean)
+        .reduce((acc, attr) => {
+          const [name, value] = attr.split('=')
+          acc[name] = value ? value.replace(/['"]/g, '') : true
+          return acc
+        }, {})
+
+      /** Remove the <template></template> */
+      content =
+        content.slice(0, templateMatch.index) +
+        templateCode +
+        content.slice(templateMatch.index + fullMatch.length)
+
+      /** Remove extra indentation */
+      content = stripIndent(content)
+
+      /** If language is HTML, just remove the <template></template> tags */
+      return markupTransformer({ content, attributes, filename })
+    },
+    script: scriptTransformer,
+    async style(assetInfo) {
+      let { code, map, dependencies } = await cssTransformer(assetInfo)
+
+      if (transformers.postcss) {
+        const result = await runTransformer('postcss', transformers.postcss, {
+          content: code,
+          map,
+          filename: assetInfo.filename,
+        })
+
+        code = result.code
+        map = result.map
+      }
+
+      return { code, map, dependencies }
+    },
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,168 +1,27 @@
-const stripIndent = require('strip-indent')
+const autoProcess = require('./autoProcess.js')
 
-const {
-  addLanguageAlias,
-  getLanguage,
-  runTransformer,
-  isFn,
-  parseAttributes,
-  getSrcContent,
-  resolveSrc,
-  throwUnsupportedError,
-  getTagPattern,
-  sliceReplace,
-  aliasOverrides,
-} = require('./utils.js')
+const coffeescript = require('./processors/coffeescript.js')
+const less = require('./processors/less.js')
+const postcss = require('./processors/postcss.js')
+const pug = require('./processors/pug.js')
+const scss = require('./processors/scss.js')
+const stylus = require('./processors/stylus.js')
 
-const TEMPLATE_PATTERN = getTagPattern('template')
+/** default auto processor */
+module.exports = autoProcess
 
-module.exports = ({
-  onBefore,
-  transformers = {},
-  aliases,
-  preserve = [],
-} = {}) => {
-  const optionsCache = {}
+/** stand-alone processors to be included manually */
 
-  if (aliases && aliases.length) {
-    addLanguageAlias(aliases)
-  }
+/** Markup */
+exports.pug = pug
 
-  const getTransformerOpts = (lang, alias) => {
-    if (isFn(transformers[alias])) return transformers[alias]
-    if (isFn(transformers[lang])) return transformers[lang]
+/** Script */
+exports.coffeescript = coffeescript
+exports.coffee = coffeescript
 
-    if (typeof optionsCache[alias] === 'undefined') {
-      let opts = transformers[lang] || {}
-
-      if (lang !== alias) {
-        opts = {
-          ...opts,
-          ...(aliasOverrides[alias] || {}),
-          ...(transformers[alias] || {}),
-        }
-      }
-
-      optionsCache[alias] = opts
-    }
-
-    return optionsCache[alias]
-  }
-
-  const getTransformerTo = targetLanguage => async ({
-    content = '',
-    attributes,
-    filename,
-  }) => {
-    const { lang, alias } = getLanguage(attributes, targetLanguage)
-    const dependencies = []
-
-    if (preserve.includes(lang) || preserve.includes(alias)) {
-      return
-    }
-
-    if (attributes.src) {
-      if (attributes.src.match(/^(https?)?:?\/\/.*$/)) {
-        return
-      }
-      const file = resolveSrc(filename, attributes.src)
-      content = await getSrcContent(file)
-      dependencies.push(file)
-    }
-
-    if (lang === targetLanguage) {
-      return {
-        code: content,
-        dependencies,
-      }
-    }
-
-    if (
-      transformers[lang] === false ||
-      (lang !== alias && transformers[alias] === false)
-    ) {
-      throwUnsupportedError(alias, filename)
-    }
-
-    const result = await runTransformer(lang, getTransformerOpts(lang, alias), {
-      content: stripIndent(content),
-      filename,
-    })
-    result.dependencies = dependencies
-    return result
-  }
-
-  const markupTransformer = async ({ content, filename }) => {
-    if (isFn(onBefore)) {
-      content = await onBefore({ content, filename })
-    }
-
-    const templateMatch = content.match(TEMPLATE_PATTERN)
-
-    /** If no <template> was found, just return the original markup */
-    if (!templateMatch) {
-      return { code: content }
-    }
-
-    let [, attributes, templateCode] = templateMatch
-
-    attributes = parseAttributes(attributes)
-    const { lang, alias } = getLanguage(attributes, 'html')
-    const dependencies = []
-
-    if (attributes.src) {
-      const file = resolveSrc(filename, attributes.src)
-      templateCode = await getSrcContent(file)
-      dependencies.push(file)
-    }
-
-    /** If language is HTML, just remove the <template></template> tags */
-    if (lang === 'html') {
-      return {
-        code: sliceReplace(templateMatch, content, templateCode),
-        dependencies,
-      }
-    }
-
-    if (transformers[lang] === false) {
-      throwUnsupportedError(lang, filename)
-    }
-
-    const { code } = await runTransformer(
-      lang,
-      getTransformerOpts(lang, alias),
-      {
-        content: stripIndent(templateCode),
-        filename,
-      },
-    )
-
-    return {
-      code: sliceReplace(templateMatch, content, code),
-      dependencies,
-    }
-  }
-
-  const scriptTransformer = getTransformerTo('javascript')
-  const cssTransformer = getTransformerTo('css')
-  const styleTransformer = assetInfo => {
-    const transformedCSS = cssTransformer(assetInfo)
-    if (transformers.postcss) {
-      return Promise.resolve(transformedCSS).then(({ code, map }) => {
-        return runTransformer('postcss', transformers.postcss, {
-          content: stripIndent(code),
-          filename: assetInfo.filename,
-          map,
-        })
-      })
-    }
-
-    return transformedCSS
-  }
-
-  return {
-    markup: markupTransformer,
-    script: scriptTransformer,
-    style: styleTransformer,
-  }
-}
+/** Style */
+exports.less = less
+exports.scss = scss
+exports.sass = scss
+exports.stylus = stylus
+exports.postcss = postcss

--- a/src/processors/coffeescript.js
+++ b/src/processors/coffeescript.js
@@ -1,0 +1,11 @@
+const { getLanguage } = require('../utils.js')
+const transformer = require('../transformers/coffeescript.js')
+
+module.exports = options => ({
+  script({ content, attributes, filename }) {
+    const { lang } = getLanguage(attributes, 'javascript')
+    if (lang !== 'coffeescript') return { code: content }
+
+    return transformer({ content, filename, options })
+  },
+})

--- a/src/processors/less.js
+++ b/src/processors/less.js
@@ -1,0 +1,11 @@
+const { getLanguage } = require('../utils.js')
+const transformer = require('../transformers/coffeescript.js')
+
+module.exports = options => ({
+  style({ content, attributes, filename }) {
+    const { lang } = getLanguage(attributes, 'css')
+    if (lang !== 'less') return { code: content }
+
+    return transformer({ content, filename, options })
+  },
+})

--- a/src/processors/postcss.js
+++ b/src/processors/postcss.js
@@ -1,0 +1,9 @@
+const transformer = require('../transformers/postcss.js')
+
+/** Adapted from https://github.com/TehShrike/svelte-preprocess-postcss */
+module.exports = options => ({
+  style({ content, attributes, filename }) {
+    /** If manually passed a plugins array, use it as the postcss config */
+    return transformer({ content, filename, options })
+  },
+})

--- a/src/processors/pug.js
+++ b/src/processors/pug.js
@@ -1,0 +1,7 @@
+const transformer = require('../transformers/pug.js')
+
+module.exports = options => ({
+  markup({ content, filename }) {
+    return transformer({ content, filename, options })
+  },
+})

--- a/src/processors/scss.js
+++ b/src/processors/scss.js
@@ -1,0 +1,20 @@
+const transformer = require('../transformers/scss.js')
+const { getIncludePaths, getLanguage } = require('../utils.js')
+
+module.exports = options => ({
+  style({ content, attributes, filename }) {
+    const { lang, alias } = getLanguage(attributes, 'css')
+    if (lang !== 'scss') return { code: content }
+
+    options = {
+      includePaths: getIncludePaths(filename),
+      ...options,
+    }
+
+    if (alias === 'sass') {
+      options.indentedSyntax = true
+    }
+
+    return transformer({ content, filename, options })
+  },
+})

--- a/src/processors/stylus.js
+++ b/src/processors/stylus.js
@@ -1,0 +1,17 @@
+const transformer = require('../transformers/scss.js')
+
+const { getIncludePaths, getLanguage } = require('../utils.js')
+
+module.exports = options => ({
+  style({ content, attributes, filename }) {
+    const { lang } = getLanguage(attributes, 'css')
+    if (lang !== 'stylus') return { code: content }
+
+    options = {
+      includePaths: getIncludePaths(filename),
+      ...options,
+    }
+
+    return transformer({ content, filename, options })
+  },
+})

--- a/src/transformers/coffeescript.js
+++ b/src/transformers/coffeescript.js
@@ -1,6 +1,6 @@
 const coffeescript = require('coffeescript')
 
-module.exports = function({ content, filename, options }) {
+module.exports = ({ content, filename, options }) => {
   const { js: code, sourceMap: map } = coffeescript.compile(content, {
     filename,
     sourceMap: true,

--- a/src/transformers/less.js
+++ b/src/transformers/less.js
@@ -1,6 +1,6 @@
 const less = require('less/lib/less-node')
 
-module.exports = function({ content, filename, options }) {
+module.exports = ({ content, filename, options }) => {
   return less
     .render(content, {
       sourceMap: {},

--- a/src/transformers/pug.js
+++ b/src/transformers/pug.js
@@ -1,6 +1,6 @@
 const pug = require('pug')
 
-module.exports = function({ content, filename, options }) {
+module.exports = ({ content, filename, options }) => {
   options = {
     doctype: 'html',
     filename,

--- a/src/transformers/scss.js
+++ b/src/transformers/scss.js
@@ -2,7 +2,7 @@ const sass = require('node-sass')
 
 const { getIncludePaths } = require('../utils.js')
 
-module.exports = function({ content, filename, options }) {
+module.exports = ({ content, filename, options }) => {
   options = {
     includePaths: getIncludePaths(filename),
     ...options,
@@ -22,6 +22,7 @@ module.exports = function({ content, filename, options }) {
         resolve({
           code: result.css.toString(),
           map: result.map ? result.map.toString() : undefined,
+          dependencies: result.stats.includedFiles,
         })
       },
     )

--- a/src/transformers/stylus.js
+++ b/src/transformers/stylus.js
@@ -2,7 +2,7 @@ const stylus = require('stylus')
 
 const { getIncludePaths } = require('../utils.js')
 
-module.exports = function({ content, filename, options }) {
+module.exports = ({ content, filename, options }) => {
   options = {
     includePaths: getIncludePaths(filename),
     ...options,

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,38 @@
+const { readFileSync } = require('fs')
+const { resolve } = require('path')
+const {
+  compile: svelteCompile,
+  preprocess: sveltePreprocess,
+} = require('svelte/compiler.js')
+
+exports.preprocess = async (input, opts) => {
+  const preprocessed = await sveltePreprocess(input, {
+    filename: resolve(__dirname, 'App.svelte'),
+    ...opts,
+  })
+  return preprocessed.toString()
+}
+
+exports.compile = async (input, magicOpts) => {
+  const preprocessed = await exports.preprocess(input, magicOpts)
+  const { js, css } = svelteCompile(preprocessed.toString(), {
+    css: true,
+  })
+
+  return { js, css }
+}
+
+exports.doesCompileThrow = async (input, opts) => {
+  let didThrow = false
+  try {
+    await exports.compile(input, opts)
+  } catch (err) {
+    didThrow = true
+  }
+  return didThrow
+}
+
+exports.getFixtureContent = file =>
+  readFileSync(resolve(__dirname, 'fixtures', file))
+    .toString()
+    .trim()


### PR DESCRIPTION
This PR keeps this package backwards compatible and introduces the optional standalone processors in case someone wants configure their preprocess step using [v3 preprocessors list](https://v3.svelte.technology/docs#svelte-preprocess).

TODO: standalone processors documentation