### PR TITLE
feat: 🎸 global style

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,28 @@ Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Co
 </style>
 ```
 
+### Global style support
+
+Use `globalStyle` preprocess or `global` attribute to apply styles to a selector globally.
+
+```html
+<style global lang="scss">
+  $color: red;
+  div {
+    color: $color;
+  }
+</style>
+```
+
+```js
+import { scss, globalStyle } from 'svelte-preprocess'
+
+svelte.preprocess(input, [
+  globalStyle(),
+]).then(...)
+```
+
+
 ## Usage
 
 ### Auto Preprocessing

--- a/README.md
+++ b/README.md
@@ -42,13 +42,27 @@ _Note: only for auto preprocessing_
 <style src="./style.css"></style>
 ```
 
+### Global style support
+
+Add a `global` attribute to your `style` tag and instead of scoping the css, all of its content will be interpreted as global style.
+
+```html
+<style global>
+  div {
+    color: red;
+  }
+</style>
+```
+
 ### Preprocessors support
 
 Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Coffeescript`, `TypeScript`, `Pug` and `PostCSS`.
 
 ```html
 <template lang="pug">
-  div Hey
+  div Posts
+  +each('posts as post')
+    a(href="{post.url}") {post.title}
 </template>
 
 <script type="text/coffeescript">
@@ -80,40 +94,18 @@ Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Co
 <!-- Or -->
 
 <style type="text/stylus">
-  $color = red
+  $color=red
 
   div
     color: $color;
 </style>
 ```
 
-### Global style support
-
-Use `globalStyle` preprocess or `global` attribute to apply styles to a selector globally.
-
-```html
-<style global lang="scss">
-  $color: red;
-  div {
-    color: $color;
-  }
-</style>
-```
-
-```js
-import { scss, globalStyle } from 'svelte-preprocess'
-
-svelte.preprocess(input, [
-  globalStyle(),
-]).then(...)
-```
-
-
 ## Usage
 
 ### Auto Preprocessing
 
-In auto preprocessing mode, `svelte-preprocess` automatically use the respective preprocessor for your code based on your `type="..."` or `lang="..."` attributes.
+In auto preprocessing mode, `svelte-preprocess` automatically use the respective preprocessor for your code based on your `type="..."` or `lang="..."` attributes. It also handles the `<template>` tag for markup, external files and global styling.
 
 #### Basic
 
@@ -214,15 +206,24 @@ svelte.preprocess(input, preprocess(options)).then(...)
 
 ### Standalone processors
 
-Instead of a single processor, [Svelte v3 has added support for multiple processors](https://v3.svelte.technology/docs#svelte-preprocess). In case you want to manually configure your preprocessing step, `svelte-preprocess` exports these named processors: `pug`, `coffeescript` or `coffee`, `less`, `scss` or `sass`, `stylus`, `postcss`.
+Instead of a single processor, [Svelte v3 has added support for multiple processors](https://v3.svelte.technology/docs#svelte-preprocess). In case you want to manually configure your preprocessing step, `svelte-preprocess` exports these named processors:
+
+- `pug`
+- `coffeescript` or `coffee`
+- `less`
+- `scss` or `sass`
+- `stylus`
+- `postcss`
+- `globalStyle` - transform `<style global>` into global styles.
 
 ```js
-import { scss, coffeescript, pug } from 'svelte-preprocess'
+import { scss, coffeescript, pug, globalStyle } from 'svelte-preprocess'
 
 svelte.preprocess(input, [
   pug(),
   coffeescript(),
   scss(),
+  globalStyle()
 ]).then(...)
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ _Note: only for auto preprocessing_
 
 Add a `global` attribute to your `style` tag and instead of scoping the css, all of its content will be interpreted as global style.
 
+_Note: needs postcss to be installed_
+
 ```html
 <style global>
   div {

--- a/src/autoProcess.js
+++ b/src/autoProcess.js
@@ -8,6 +8,7 @@ const {
   getSrcContent,
   resolveSrc,
   throwUnsupportedError,
+  globalifySelectors,
 } = require('./utils.js')
 
 const SVELTE_MAJOR_VERSION = +version[0]
@@ -161,6 +162,10 @@ module.exports = ({ onBefore, aliases, preserve = [], ...rest } = {}) => {
         code = result.code
         map = result.map
         dependencies = dependencies.concat(result.dependencies)
+      }
+
+      if (assetInfo.attributes.global) {
+        code = globalifySelectors(code)
       }
 
       return { code, map, dependencies }

--- a/src/index.js
+++ b/src/index.js
@@ -18,3 +18,5 @@ module.exports.scss = opts => require(`./processors/scss.js`)(opts)
 module.exports.sass = opts => require(`./processors/scss.js`)(opts)
 module.exports.stylus = opts => require(`./processors/stylus.js`)(opts)
 module.exports.postcss = opts => require(`./processors/postcss.js`)(opts)
+module.exports.globalStyle = opts =>
+  require(`./processors/globalStyle.js`)(opts)

--- a/src/processors/globalStyle.js
+++ b/src/processors/globalStyle.js
@@ -1,0 +1,11 @@
+const transformer = require('../transformers/globalStyle.js')
+
+module.exports = options => {
+  return {
+    style({ content, attributes, filename }) {
+      if (!attributes.global) return { code: content }
+
+      return transformer({ content, filename, options })
+    },
+  }
+}

--- a/src/transformers/globalStyle.js
+++ b/src/transformers/globalStyle.js
@@ -1,0 +1,7 @@
+const { globalifySelectors } = require('../utils')
+
+module.exports = ({ content, filename, options }) => {
+  const code = globalifySelectors(content)
+
+  return { code }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,12 +37,11 @@ exports.addLanguageAlias = entries =>
   entries.forEach(entry => LANG_DICT.set(...entry))
 
 /** Paths used by preprocessors to resolve @imports */
-exports.getIncludePaths = fromFilename =>
-  [
-    process.cwd(),
-    fromFilename.length && dirname(fromFilename),
-    resolve(process.cwd(), 'node_modules'),
-  ].filter(Boolean)
+exports.getIncludePaths = fromFilename => [
+  process.cwd(),
+  fromFilename.length && dirname(fromFilename),
+  resolve(process.cwd(), 'node_modules'),
+].filter(Boolean)
 
 exports.getLanguage = (attributes, defaultLang) => {
   let lang = defaultLang
@@ -77,9 +76,7 @@ exports.runTransformer = (name, options, { content, filename }) => {
     return TRANSFORMERS[name]({ content, filename, options })
   } catch (e) {
     throwError(
-      `Error transforming '${name}'. Message:\n${e.message}\nStack:\n${
-        e.stack
-      }`,
+      `Error transforming '${name}'. Message:\n${e.message}\nStack:\n${e.stack}`,
     )
   }
 }
@@ -91,4 +88,13 @@ exports.requireAny = (...modules) => {
     } catch (e) {}
   }
   throw new Error(`Cannot find any of modules: ${modules}`)
+}
+
+exports.globalifySelectors = code => {
+  const selectorRe = /^(?!.*@media)[\t ]*([a-zA-Z#.:*[][^{/]*\s*){[\s\S]*?}/gm
+
+  function replacer(match, p1) {
+    return match.replace(p1, `:global(${p1.trim()})`)
+  }
+  return code.replace(selectorRe, replacer)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,11 +37,12 @@ exports.addLanguageAlias = entries =>
   entries.forEach(entry => LANG_DICT.set(...entry))
 
 /** Paths used by preprocessors to resolve @imports */
-exports.getIncludePaths = fromFilename => [
-  process.cwd(),
-  fromFilename.length && dirname(fromFilename),
-  resolve(process.cwd(), 'node_modules'),
-].filter(Boolean)
+exports.getIncludePaths = fromFilename =>
+  [
+    process.cwd(),
+    fromFilename.length && dirname(fromFilename),
+    resolve(process.cwd(), 'node_modules'),
+  ].filter(Boolean)
 
 exports.getLanguage = (attributes, defaultLang) => {
   let lang = defaultLang
@@ -62,7 +63,6 @@ exports.getLanguage = (attributes, defaultLang) => {
 }
 
 const TRANSFORMERS = {}
-
 exports.runTransformer = (name, options, { content, filename }) => {
   if (exports.isFn(options)) {
     return options({ content, filename })
@@ -76,7 +76,9 @@ exports.runTransformer = (name, options, { content, filename }) => {
     return TRANSFORMERS[name]({ content, filename, options })
   } catch (e) {
     throwError(
-      `Error transforming '${name}'. Message:\n${e.message}\nStack:\n${e.stack}`,
+      `Error transforming '${name}'. Message:\n${e.message}\nStack:\n${
+        e.stack
+      }`,
     )
   }
 }
@@ -88,13 +90,4 @@ exports.requireAny = (...modules) => {
     } catch (e) {}
   }
   throw new Error(`Cannot find any of modules: ${modules}`)
-}
-
-exports.globalifySelectors = code => {
-  const selectorRe = /^(?!.*@media)[\t ]*([a-zA-Z#.:*[][^{/]*\s*){[\s\S]*?}/gm
-
-  function replacer(match, p1) {
-    return match.replace(p1, `:global(${p1.trim()})`)
-  }
-  return code.replace(selectorRe, replacer)
 }

--- a/test/transformers/globalStyle.test.js
+++ b/test/transformers/globalStyle.test.js
@@ -1,0 +1,11 @@
+const autoProcess = require('../../src')
+const { preprocess } = require('../utils.js')
+
+describe('transformer - globalStyle', () => {
+  it('should wrap selector in :global(...) modifier', async () => {
+    const template = `<style global>div{color:red}</style>`
+    const opts = autoProcess()
+    const preprocessed = await preprocess(template, opts)
+    expect(preprocessed.toString()).toContain(':global(div)')
+  })
+})

--- a/test/transformers/globalStyle.test.js
+++ b/test/transformers/globalStyle.test.js
@@ -3,9 +3,23 @@ const { preprocess } = require('../utils.js')
 
 describe('transformer - globalStyle', () => {
   it('should wrap selector in :global(...) modifier', async () => {
-    const template = `<style global>div{color:red}</style>`
+    const template = `<style global>@media(min-width:10px){div{color:red}}.test{}</style>`
     const opts = autoProcess()
     const preprocessed = await preprocess(template, opts)
-    expect(preprocessed.toString()).toContain(':global(div)')
+    expect(preprocessed.toString()).toContain(
+      '@media(min-width:10px){:global(div){color:red}}:global(.test){}',
+    )
+  })
+  it('should wrap selector in :global(...) only if needed', async () => {
+    const template = `<style global>
+.test{}:global(.foo){}
+@keyframes a {from{} to{}}
+    </style>`
+    const opts = autoProcess()
+    const preprocessed = await preprocess(template, opts)
+    expect(preprocessed.toString()).toContain(
+      `:global(.test){}:global(.foo){}
+@keyframes a {from{} to{}}`,
+    )
   })
 })


### PR DESCRIPTION
### Global style support

Use `globalStyle` preprocess or `global` attribute to apply styles to a selector globally.

```html
<style global lang="scss">
  $color: red;
  div {
    color: $color;
  }
</style>
```

```js
import { scss, globalStyle } from 'svelte-preprocess'

svelte.preprocess(input, [
  globalStyle(),
]).then(...)
```
