### PR TITLE
Make @keyframe at-rules global.

### DIFF
--- a/src/transformers/globalStyle.js
+++ b/src/transformers/globalStyle.js
@@ -1,6 +1,12 @@
 const postcss = require('postcss')
 
-const globalifyPlugin = root =>
+const globalifyPlugin = root => {
+  root.walkAtRules(/keyframes$/, atrule => {
+    if (!atrule.params.startsWith('-global-')) {
+      atrule.params = '-global-' + atrule.params
+    }
+  })
+
   root.walkRules(rule => {
     if (rule.parent && rule.parent.name === 'keyframes') {
       return
@@ -10,6 +16,7 @@ const globalifyPlugin = root =>
       selector.startsWith(':global') ? selector : `:global(${selector})`,
     )
   })
+}
 
 module.exports = async ({ content, filename, map = undefined }) => {
   const { css, map: newMap } = await postcss()

--- a/test/transformers/globalStyle.test.js
+++ b/test/transformers/globalStyle.test.js
@@ -19,7 +19,17 @@ describe('transformer - globalStyle', () => {
     const preprocessed = await preprocess(template, opts)
     expect(preprocessed.toString()).toContain(
       `:global(.test){}:global(.foo){}
-@keyframes a {from{} to{}}`,
+@keyframes -global-a {from{} to{}}`,
+    )
+  })
+  it('should prefix @keyframes names with \'-global-\' only if needed', async () => {
+    const template = `<style global>
+@keyframes a {from{} to{}}@keyframes -global-b {from{} to{}}
+    </style>`
+    const opts = autoProcess()
+    const preprocessed = await preprocess(template, opts)
+    expect(preprocessed.toString()).toContain(
+      `@keyframes -global-a {from{} to{}}@keyframes -global-b {from{} to{}}`,
     )
   })
 })


### PR DESCRIPTION
Prefix all @keyframe at-rule names with '-global-'.
For example:
  @keyframes slide-in {from{} to{}}
will become:
  @keyframes -global-slide-in {from{} to{}}