### PR TITLE
Add `sass` installation line to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The preprocessor module installation is up to the developer.
 - `coffeescript`: `npm install -D coffeescript`
 - `typescript`: `npm install -D typescript`
 - `less`: `npm install -D less`
-- `sass`: `npm install -D node-sass`
+- `sass`: `npm install -D node-sass` or `npm install -D sass`
 - `pug`: `npm install -D pug`
 - `stylus`: `npm install -D stylus`
 


### PR DESCRIPTION
According to the source code the Sass-transformer works with `node-sass` or `sass`, but there is no notes about it in the README.

I've added installation line just to mark this fact, because it is important. My first impression was that it can't work with `sass`.