### PR TITLE
add an option to render scss synchronously via renderSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ const options = {
   /** Disable a language by setting it to 'false' */
   scss: false,
 
+  /** or pass an option to render synchronously and any other node-sass or sass options*/
+  scss: {
+    renderSync: true
+  },
+
   /**  Pass options to the default preprocessor method */
   stylus: {
     paths: ['node_modules'],

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -26,7 +26,7 @@ export interface Babel extends BabelOptions {
 }
 
 export type Pug = PugOptions;
-export type Sass = Omit<SassOptions, 'file'>;
+export type Sass = Omit<SassOptions, 'file'> & { renderSync?: boolean };
 // from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/less/index.d.ts#L80
 export interface Less {
   paths?: string[];

--- a/test/transformers/scss.test.ts
+++ b/test/transformers/scss.test.ts
@@ -4,7 +4,7 @@ import getAutoPreprocess from '../../src';
 import { preprocess } from '../utils';
 
 describe('transformer - scss', () => {
-  it('should prepend scss content via `data` option property', async () => {
+  it('should prepend scss content via `data` option property - via defaul async render', async () => {
     const template = `<style lang="scss"></style>`;
     const opts = getAutoPreprocess({
       scss: {
@@ -15,7 +15,7 @@ describe('transformer - scss', () => {
     expect(preprocessed.toString()).toContain('red');
   });
 
-  it('should return @imported files as dependencies', async () => {
+  it('should return @imported files as dependencies - via default async render', async () => {
     const template = `<style lang="scss">@import "fixtures/style.scss";</style>`;
     const opts = getAutoPreprocess();
     const preprocessed = await preprocess(template, opts);
@@ -23,4 +23,29 @@ describe('transformer - scss', () => {
       resolve(__dirname, '..', 'fixtures', 'style.scss').replace(/[\\/]/g, '/'),
     );
   });
+
+  it('should prepend scss content via `data` option property - via renderSync', async () => {
+    const template = `<style lang="scss"></style>`;
+    const opts = getAutoPreprocess({
+      scss: {
+        data: '$color:blue;div{color:$color}',
+        renderSync: true,
+      },
+    });
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toContain('blue');
+  });
+
+  it('should return @imported files as dependencies - via renderSync', async () => {
+    const template = `<style lang="scss">@import "fixtures/style.scss";</style>`;
+    const opts = getAutoPreprocess({
+      scss: {
+        renderSync: true,
+      },
+    });
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.dependencies).toContain(
+      resolve(__dirname, '..', 'fixtures', 'style.scss').replace(/[\\/]/g, '/'),
+    );
+  });  
 });


### PR DESCRIPTION
### Synchronous SCSS Compiling

- [ ] This adds a way to synchronously compile SCSS via sass or node-sass. According to sass:
>When using Dart Sass, renderSync() is almost twice as fast as render() by default, due to the overhead of making the entire evaluation process asynchronous.
Just need to pass `renderSync` as `true` with scss options:
```
	scss: {
		includePaths: ['theme', 'src/styles'],
		renderSync: true,
	}
```
- [ ] Allows a developer to choose whether to use the async `render` method, which is the default, or the synchronous and potentially faster `renderSync` method.  Both sass and node-sass support `renderSync`
- [ ] All of the current and new tests should pass, the output from the scss transformer remains the same utilizing the same async method with resolve and reject on error.  (the actual call though is synchronous with a try/catch block) 

### Tests

- [ ] Added a couple of tests of the new option and they pass
