### PR TITLE
Avoid reporting 'Cannot find name '{0}'. Did you mean '{1}'?' for reactive variables

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -97,9 +97,10 @@ function isValidSvelteReactiveValueDiagnostic(
   /** if error message doesn't contain a reactive value, do nothing */
   if (!diagnostic.messageText.includes('$')) return true;
 
-  const matches = diagnostic.messageText.match(TS2552_REGEX);
+  const [, usedVar, proposedVar] =
+    diagnostic.messageText.match(TS2552_REGEX) || [];
 
-  return !(matches[1] && matches[2] && matches[1] === matches[2]);
+  return !(usedVar && proposedVar && usedVar === proposedVar);
 }
 
 function compileFileFromMemory(

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -84,6 +84,24 @@ const TS_TRANSFORMERS = {
   before: [importTransformer],
 };
 
+const TS2552_REGEX = /Cannot find name '\$([a-zA-Z0-9_]+)'. Did you mean '([a-zA-Z0-9_]+)'\?/i;
+function isValidSvelteReactiveValueDiagnostic(
+  filename: string,
+  diagnostic: any,
+): boolean {
+  if (diagnostic.code !== 2552) return true;
+
+  /** if the importee is not a svelte file, do nothing */
+  if (!isSvelteFile(filename)) return true;
+
+  /** if error message doesn't contain a reactive value, do nothing */
+  if (!diagnostic.messageText.includes('$')) return true;
+
+  const matches = diagnostic.messageText.match(TS2552_REGEX);
+
+  return !(matches[1] && matches[2] && matches[1] === matches[2]);
+}
+
 function compileFileFromMemory(
   compilerOptions: CompilerOptions,
   { filename, content }: { filename: string; content: string },
@@ -155,7 +173,11 @@ function compileFileFromMemory(
   const diagnostics = [
     ...emitResult.diagnostics,
     ...ts.getPreEmitDiagnostics(program),
-  ].filter(diagnostic => isValidSvelteImportDiagnostic(filename, diagnostic));
+  ].filter(
+    diagnostic =>
+      isValidSvelteImportDiagnostic(filename, diagnostic) &&
+      isValidSvelteReactiveValueDiagnostic(filename, diagnostic),
+  );
 
   return { code, map, diagnostics };
 }

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -141,5 +141,26 @@ describe('transformer - typescript', () => {
       );
       expect(diagnostics.some(d => d.code === 2307)).toBe(true);
     });
+
+    it('should NOT report a mismatched variable name error when using reactive variables', async () => {
+      const { diagnostics } = await transpile(
+        `
+          const user = {};
+          $user.name = "test";
+        `,
+      );
+      expect(diagnostics.some(d => d.code === 2552)).toBe(false);
+    });
+    
+    it('should report a mismatched variable name error', async () => {
+      const { diagnostics } = await transpile(
+        `
+          const user = {};
+          xuser.name = "test";
+        `,
+      );
+      expect(diagnostics.some(d => d.code === 2552)).toBe(true);
+    });
+
   });
 });


### PR DESCRIPTION
### Explain what this does

Hi @kaisermann ,

Nice work on the library!

When using [Store reactive variables](https://svelte.dev/tutorial/writable-stores), e.g **$user** that are prefixed with **$**, TypeScript reports a TS2552 error: `'Cannot find name '{0}'. Did you mean '{1}'?' ` although the variable is declared and valid, so this PR supresses this error if the variable in fact exists, and we've used a similar solution to what you did with [isValidSvelteImportDiagnostic](https://github.com/kaisermann/svelte-preprocess/blob/master/src/transformers/typescript.ts#L47) .

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`