### PR TITLE
feat: 🎸 add `replace` transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Which allows to write your component like:
 
 ```html
 @if(process.env.NODE_ENV !== 'development')
-  <h1>Production environment!</h1>
+<h1>Production environment!</h1>
 @endif
 ```
 
@@ -357,11 +357,14 @@ In case you want to manually configure your preprocessing step, `svelte-preproce
 
 - `pug`
 - `coffeescript` or `coffee`
+- `typescript`
 - `less`
 - `scss` or `sass`
 - `stylus`
 - `postcss`
+- `babel`
 - `globalStyle` - transform `<style global>` into global styles.
+- `replace` - replace string patterns in your markup.
 
 ```js
 import { scss, coffeescript, pug, globalStyle } from 'svelte-preprocess';

--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ const options = {
     [/@then\s*(?:\((.*?)\))?$/gim, '{:then $1}'],
     [/@catch\s*(?:\((.*?)\))?$$/gim, '{:catch $1}'],
     [/@endawait$/gim, '{/await}'],
+    [/@debug\s*\((.*?)\)$/gim, '{@debug $1}'],
+    [/@html\s*\((.*?)\)$/gim, '{@html $1}'],
   ];
 };
 

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -14,7 +14,7 @@ import {
   TransformerOptions,
   Preprocessor,
   Options,
-  ProcessedScript,
+  Processed,
 } from './types';
 
 interface Transformers {
@@ -211,7 +211,7 @@ export function autoPreprocess(
       return { code, map, dependencies };
     },
     async script({ content, attributes, filename }) {
-      const transformResult: ProcessedScript = await scriptTransformer({
+      const transformResult: Processed = await scriptTransformer({
         content,
         attributes,
         filename,

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -27,6 +27,7 @@ interface Transformers {
   coffeescript?: TransformerOptions<Options.Coffeescript>;
   pug?: TransformerOptions<Options.Pug>;
   globalStyle?: TransformerOptions<Options.Typescript>;
+  replace?: Options.Replace;
   [languageName: string]: TransformerOptions<any>;
 }
 
@@ -163,6 +164,15 @@ export function autoPreprocess(
           );
         }
         content = await onBefore({ content, filename });
+      }
+
+      if (transformers.replace) {
+        const result = await runTransformer('replace', transformers.replace, {
+          content,
+          filename,
+        });
+
+        content = result.code;
       }
 
       const templateMatch = content.match(markupPattern);

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -167,12 +167,13 @@ export function autoPreprocess(
       }
 
       if (transformers.replace) {
-        const result = await runTransformer('replace', transformers.replace, {
-          content,
-          filename,
-        });
+        const transformed = await runTransformer(
+          'replace',
+          transformers.replace,
+          { content, filename },
+        );
 
-        content = result.code;
+        content = transformed.code;
       }
 
       const templateMatch = content.match(markupPattern);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export { default as stylus } from './processors/stylus';
 export { default as postcss } from './processors/postcss';
 export { default as globalStyle } from './processors/globalStyle';
 export { default as babel } from './processors/babel';
+export { default as replace } from './processors/replace';

--- a/src/processors/replace.ts
+++ b/src/processors/replace.ts
@@ -1,0 +1,8 @@
+import { PreprocessorGroup, Options } from '../types';
+
+export default (options: Options.Replace): PreprocessorGroup => ({
+  async markup({ content, filename }) {
+    const { default: transformer } = await import('../transformers/replace');
+    return transformer({ content, filename, options });
+  },
+});

--- a/src/transformers/replace.ts
+++ b/src/transformers/replace.ts
@@ -1,0 +1,18 @@
+import { Transformer, Options } from '../types';
+
+const transformer: Transformer<Options.Replace> = async ({
+  content,
+  options,
+}) => {
+  let newContent = content;
+
+  for (const [regex, replacer] of options) {
+    newContent = newContent.replace(regex, replacer);
+  }
+
+  return {
+    code: newContent,
+  };
+};
+
+export default transformer;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,14 @@
-import { Processed, Preprocessor } from 'svelte/types/compiler/preprocess';
+import {
+  Processed as SvelteProcessed,
+  Preprocessor,
+} from 'svelte/types/compiler/preprocess';
 
 import * as Options from './options';
 
 export { Options };
 
 export {
-  Processed,
+  Processed as SvelteProcessed,
   PreprocessorGroup,
   Preprocessor,
 } from 'svelte/types/compiler/preprocess';
@@ -22,13 +25,13 @@ export interface TransformerArgs<T> {
   options?: T;
 }
 
-export type ProcessedScript = Processed & {
+export type Processed = SvelteProcessed & {
   diagnostics?: unknown[];
 };
 
 export type Transformer<T> = (
   args: TransformerArgs<T>,
-) => ProcessedScript | Promise<ProcessedScript>;
+) => Processed | Promise<Processed>;
 
 export type TransformerOptions<T> =
   | boolean

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ export interface TransformerArgs<T> {
 }
 
 export type Processed = SvelteProcessed & {
-  diagnostics?: unknown[];
+  diagnostics?: any[];
 };
 
 export type Transformer<T> = (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export type ProcessedScript = Processed & {
 
 export type Transformer<T> = (
   args: TransformerArgs<T>,
-) => Processed | Promise<Processed>;
+) => ProcessedScript | Promise<ProcessedScript>;
 
 export type TransformerOptions<T> =
   | boolean

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -4,6 +4,10 @@ import { Options as PugOptions } from 'pug';
 import { CompilerOptions } from 'typescript';
 import { TransformOptions as BabelOptions } from '@babel/core';
 
+export type Replace = Array<
+  [RegExp, (substring: string, ...args: any[]) => string | string]
+>;
+
 export interface Coffeescript {
   inlineMap?: boolean;
   filename?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,7 +129,7 @@ export const runTransformer = async (
   name: string,
   options: TransformerOptions<any>,
   { content, map, filename }: TransformerArgs<any>,
-) => {
+): Promise<ReturnType<Transformer<unknown>>> => {
   if (typeof options === 'function') {
     return options({ content, map, filename });
   }

--- a/test/transformers/replace.test.ts
+++ b/test/transformers/replace.test.ts
@@ -1,0 +1,111 @@
+import autoProcess from '../../src';
+import { preprocess } from '../utils';
+
+const options = [
+  [/@if\s*\((.*?)\)$/gim, '{#if $1}'],
+  [/@elseif\s*\((.*?)\)$/gim, '{:else if $1}'],
+  [/@else$/gim, '{:else}'],
+  [/@endif$/gim, '{/if}'],
+  [/@each\s*\((.*?)\)$/gim, '{#each $1}'],
+  [/@endeach$/gim, '{/each}'],
+  [/@await\s*\((.*?)\)$/gim, '{#await $1}'],
+  [/@then\s*(?:\((.*?)\))?$/gim, '{:then $1}'],
+  [/@catch\s*(?:\((.*?)\))?$$/gim, '{:catch $1}'],
+  [/@endawait$/gim, '{/await}'],
+];
+
+describe('transformer - regex', () => {
+  it('replaces string patterns in markup with string patterns', async () => {
+    const template = `
+@if (foo && bar)
+    <div>hey</div>
+@elseif (baz < 0 && (baz || bar))
+    <div>yo</div>
+@endif
+
+@each(expression as name, index (key))
+    <li>foo</li>
+@else
+    <div>foo</div>
+@endeach
+
+@await(promise)
+    awaiting
+@then
+    then
+@then(value)
+    then value
+@catch
+    catch
+@endawait`.repeat(2);
+    const opts = autoProcess({ regex: options });
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toMatchInlineSnapshot(`
+      "
+      @if (foo && bar)
+          <div>hey</div>
+      @elseif (baz < 0 && (baz || bar))
+          <div>yo</div>
+      @endif
+
+      @each(expression as name, index (key))
+          <li>foo</li>
+      @else
+          <div>foo</div>
+      @endeach
+
+      @await(promise)
+          awaiting
+      @then
+          then
+      @then(value)
+          then value
+      @catch
+          catch
+      @endawait
+      @if (foo && bar)
+          <div>hey</div>
+      @elseif (baz < 0 && (baz || bar))
+          <div>yo</div>
+      @endif
+
+      @each(expression as name, index (key))
+          <li>foo</li>
+      @else
+          <div>foo</div>
+      @endeach
+
+      @await(promise)
+          awaiting
+      @then
+          then
+      @then(value)
+          then value
+      @catch
+          catch
+      @endawait"
+    `);
+  });
+
+  it('replaces string patterns in markup with string patterns', async () => {
+    const template = `<script>
+      let isDEV = process.env.NODE_ENV === 'development';
+    </script>`;
+
+    const opts = autoProcess({
+      replace: [
+        [
+          /process\.env\.(\w+)/g,
+          (_: string, match: string) => JSON.stringify(process.env[match]),
+        ],
+      ],
+    });
+
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toMatchInlineSnapshot(`
+"<script>
+      let isDEV = \\"test\\" === 'development';
+    </script>"
+`);
+  });
+});


### PR DESCRIPTION
It came to my mind that it would useful to have an easy way to replace values inside svelte components like what `Webpack.DefinePlugin` does. I know people can use the webpack/rollup plugin instead, but adding a `markup` transformer guarantees that we're replacing values before the compilation step, which allows some interesting use cases.